### PR TITLE
Fix inconsistent ID for compromise HP output

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,7 +324,7 @@
                             <div class="total-hp-scenario">
                                 <h4 id="compromiseHpScenarioTitleParent"><i class="fas fa-chart-area"></i> <span id="compromiseHpScenarioTitle">チーム合計耐久値(妥協)</span></h4>
                                 <div class="redeploy-char-info">
-                                    <span class="info-label">合計獲得耐久値:</span> <span id="minGainedHpHpSpan" class="info-value">--</span>
+                                    <span class="info-label">合計獲得耐久値:</span> <span id="minGainedHpSpan" class="info-value">--</span>
                                 </div>
                                 <button class="total-hp-accordion-header" aria-expanded="false">
                                     <span class="total-hp-accordion-title">撃墜順序と獲得HP</span>

--- a/js/domElements.js
+++ b/js/domElements.js
@@ -67,7 +67,7 @@ export const idealGainedHpSpan = document.getElementById('idealGainedHp');
 export const idealSequenceList = document.getElementById('idealSequenceList');
 
 export const compromiseHpScenarioTitleSpan = document.getElementById('compromiseHpScenarioTitle');
-export const minGainedHpHpSpan = document.getElementById('minGainedHpHpSpan');
+export const minGainedHpSpan = document.getElementById('minGainedHpSpan');
 export const minSequenceList = document.getElementById('minSequenceList');
 
 export const bombHpScenarioTitleSpan = document.getElementById('bombHpScenarioTitle');

--- a/js/eventHandlers.js
+++ b/js/eventHandlers.js
@@ -136,7 +136,7 @@ function handleShareTotalHpResult() {
 
     let summaryText = `【星の翼 チーム耐久予測】\n自機: ${playerChar.name}(コスト${playerChar.cost.toFixed(1)})\n相方: ${partnerChar.name}(コスト${partnerChar.cost.toFixed(1)})\n\n`;
     summaryText += `理想耐久: ${DOM.idealGainedHpSpan.textContent}\n`;
-    summaryText += `妥協耐久: ${DOM.minGainedHpHpSpan.textContent}\n`;
+    summaryText += `妥協耐久: ${DOM.minGainedHpSpan.textContent}\n`;
     summaryText += `爆弾耐久: ${DOM.bombGainedHpSpan.textContent}\n`;
     summaryText += `最低耐久: ${DOM.lowestGainedHpSpan.textContent}\n`;
     summaryText += "\n詳細はこちらでチェック！";

--- a/js/ui.js
+++ b/js/ui.js
@@ -325,7 +325,7 @@ export function displayTotalTeamHpResults(scenarios) {
             if (DOM.idealGainedHpSpan) DOM.idealGainedHpSpan.textContent = '--';
             if (DOM.idealSequenceList) DOM.idealSequenceList.innerHTML = '';
             if (DOM.compromiseHpScenarioTitleSpan) DOM.compromiseHpScenarioTitleSpan.textContent = 'チーム合計耐久値(妥協)';
-            if (DOM.minGainedHpHpSpan) DOM.minGainedHpHpSpan.textContent = '--';
+            if (DOM.minGainedHpSpan) DOM.minGainedHpSpan.textContent = '--';
             if (DOM.minSequenceList) DOM.minSequenceList.innerHTML = '';
             if (DOM.bombHpScenarioTitleSpan) DOM.bombHpScenarioTitleSpan.textContent = 'チーム合計耐久値(爆弾)';
             if (DOM.bombGainedHpSpan) DOM.bombGainedHpSpan.textContent = '--';
@@ -372,7 +372,7 @@ export function displayTotalTeamHpResults(scenarios) {
     if(DOM.idealSequenceList) { DOM.idealSequenceList.innerHTML = ''; DOM.idealSequenceList.appendChild(generateListItems(idealScenario.sequence));}
 
     if(DOM.compromiseHpScenarioTitleSpan) DOM.compromiseHpScenarioTitleSpan.textContent = compromiseScenario.name;
-    if(DOM.minGainedHpHpSpan) DOM.minGainedHpHpSpan.textContent = compromiseScenario.totalHp?.toLocaleString() || '--';
+    if(DOM.minGainedHpSpan) DOM.minGainedHpSpan.textContent = compromiseScenario.totalHp?.toLocaleString() || '--';
     if(DOM.minSequenceList) { DOM.minSequenceList.innerHTML = ''; DOM.minSequenceList.appendChild(generateListItems(compromiseScenario.sequence));}
 
     if(DOM.bombHpScenarioTitleSpan) DOM.bombHpScenarioTitleSpan.textContent = bombScenario.name;


### PR DESCRIPTION
## Summary
- fix typo in compromise total HP span id
- update DOM element reference and event handler
- adjust UI update for compromise scenario

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f48862a2483289283fdb017199bfe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the display and sharing of the "Team Total Durability (Compromise)" value by fixing an incorrect element reference. The gained durability value now appears and shares correctly in the relevant section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->